### PR TITLE
FIX: broken links in knowledgebase

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -1,5 +1,5 @@
 nav:
-  - intro.md
+  - index.md
   - git/
   - python/
   - labels.md

--- a/docs/git/github-workflows.md
+++ b/docs/git/github-workflows.md
@@ -4,7 +4,7 @@
 
 GitHub Workflows are automated processes that help you build, test, package, release, and deploy projects directly from your GitHub repository. They enable continuous integration and continuous deployment (CI/CD) through declarative YAML files stored in your `.github/workflows` directory.
 
-In the [intro to git](/git/intro/#3-branching-strategy), a recommended workflow was making all changes on separate branches, which are merged into master through a Pull Request that is reviewed by the team. Workflows allows to automate many of the check the team might want to perform. For example, you'd want to know: is the code properly [linted & formatted](/docs/python/lint.md)? Is it [type annotated](/docs/python/typing/intro.md)? Does it pass all [test cases](/docs/python/tests/intro.md)? Because even if you recommend people to use [pre-commit hooks](/docs/git/pre-commit.md), there's no guarantee that they're actually used. So you could have workflows to answer all of the questions above.
+In the [intro to git](./intro.md#3-branching-strategy), a recommended workflow was making all changes on separate branches, which are merged into master through a Pull Request that is reviewed by the team. Workflows allows to automate many of the check the team might want to perform. For example, you'd want to know: is the code properly [linted & formatted](../python/lint.md)? Is it [type annotated](../python/typing/intro.md)? Does it pass all [test cases](../python/tests/intro.md)? Because even if you recommend people to use [pre-commit hooks](../git/pre-commit.md), there's no guarantee that they're actually used. So you could have workflows to answer all of the questions above.
 
 ## Prerequisites
 
@@ -86,7 +86,7 @@ categories:                               # Organizes changes by category
 1. **Version Resolution** ([.github/workflows/release-drafter.yml](https://github.com/batistagroup/python-template/blob/master/.github/workflows/release-drafter.yml)):
     The workflow employs a semantic versioning strategy based on PR labels. Major version bumps are triggered by breaking changes, minor versions by new features in areas like quantum mechanics or tutorials, and patch versions by maintenance updates. If no specific version label is present, the system defaults to a patch version increment.
 
-When a PR is opened or updated, the workflow analyzes commit messages for keywords, automatically assigns corresponding labels, uses these labels to categorize changes in the release draft, and updates the version number based on the labels' significance. For instance, a PR with commit message "feat(quantum): Add new QM simulation" would be labeled as "quantum-mechanics", appear under "Core Science" in the changelog, trigger a minor version bump, and be formatted as "- Add new QM simulation @author (#123)". To see existing labels for the knowledgebase repo, see [labels doc](/docs/labels.md).
+When a PR is opened or updated, the workflow analyzes commit messages for keywords, automatically assigns corresponding labels, uses these labels to categorize changes in the release draft, and updates the version number based on the labels' significance. For instance, a PR with commit message "feat(quantum): Add new QM simulation" would be labeled as "quantum-mechanics", appear under "Core Science" in the changelog, trigger a minor version bump, and be formatted as "- Add new QM simulation @author (#123)". To see existing labels for the knowledgebase repo, see [labels doc](../labels.md).
 
 ### Update Major Minor Tags
 

--- a/docs/git/pre-commit.md
+++ b/docs/git/pre-commit.md
@@ -1,6 +1,6 @@
 # Pre-commit Workflows
 
-After reading docs on [linting & formatting](/docs/python/lint.md) and [typing](/docs/python/typing/intro.md), your [committing](/docs/git/intro.md) workflow will look like:
+After reading docs on [linting & formatting](../python/lint.md) and [typing](../python/typing/intro.md), your [committing](../git/intro.md) workflow will look like:
 
 ```bash
 ruff check --fix

--- a/docs/python/lint.md
+++ b/docs/python/lint.md
@@ -84,7 +84,7 @@ lint.select = ["E", "F", "UP", "B", "SIM", "I"]
 
 ### Integration with Development Tools
 
-See page on [pre-commits](/docs/git/pre-commit.md).
+See page on [pre-commits](../git/pre-commit.md).
 
 ## Ruff Formatting
 
@@ -174,7 +174,7 @@ Note the trailing comma after the last item in multi-line structures - this is a
 
 1. Run Ruff locally before committing changes
 1. Configure your IDE for automatic linting on save
-1. Use [pre-commit hooks](/docs/git/pre-commit.md) to enforce linting rules
+1. Use [pre-commit hooks](../git/pre-commit.md) to enforce linting rules
 1. Regularly update Ruff to get the latest rules and fixes
 
 ## Related Resources

--- a/docs/python/template-repo.md
+++ b/docs/python/template-repo.md
@@ -1,5 +1,5 @@
 # Python Project Template
 
-Setting proper project structure, configuring `pyproject.toml`, writing [pre-commit config](/docs/git/pre-commit.md), configuring [github workflows](/docs/git/github-workflows.md) is quite time consuming, but most importantly pretty much doesn't change from one project to another.
+Setting proper project structure, configuring `pyproject.toml`, writing [pre-commit config](../git/pre-commit.md), configuring [github workflows](../git/github-workflows.md) is quite time consuming, but most importantly pretty much doesn't change from one project to another.
 
 Which is why we created a boilerplate [python template](https://github.com/batistagroup/python-template) that is already configured with many best practices in mind.

--- a/docs/python/tests/intro.md
+++ b/docs/python/tests/intro.md
@@ -2,7 +2,7 @@
 
 Testing transforms your code from a fragile house of cards into a robust, maintainable fortress by systematically validating its behavior and documenting its intent.
 
-Admittedly, testing is not something I've fully embraced, I don't have (yet) a single codebase that has 90+% test coverage; however, the more I've worked on projects where more than one person writes the code, the more I understand their necessity. At the end of the day, just like with [typing](/python/typing/intro/#configuring-mypy), it's something you need to force yourself to do once, and after that it will become a natural part of coding.
+Admittedly, testing is not something I've fully embraced, I don't have (yet) a single codebase that has 90+% test coverage; however, the more I've worked on projects where more than one person writes the code, the more I understand their necessity. At the end of the day, just like with [typing](../typing/intro.md#configuring-mypy), it's something you need to force yourself to do once, and after that it will become a natural part of coding.
 
 ## Testing in the wild
 

--- a/docs/python/typing/intro.md
+++ b/docs/python/typing/intro.md
@@ -289,7 +289,7 @@ def get_user_ids() -> list[int]:
 
 ## Configuring mypy
 
-Enabling an automatic type checker for your codebase is quite easy. Simply `uv add mypy` in your [venv](/docs/python/essential-tools.md), and then you can run `mypy .`. Once your codebase satisfies basic rules (checked by `mypy .` call), you can try & run `mypy --strict .`. Mypy can also be added as a [pre-commit hook](/docs/git/pre-commit.md).
+Enabling an automatic type checker for your codebase is quite easy. Simply `uv add mypy` in your [venv](../essential-tools.md), and then you can run `mypy .`. Once your codebase satisfies basic rules (checked by `mypy .` call), you can try & run `mypy --strict .`. Mypy can also be added as a [pre-commit hook](../../git/pre-commit.md).
 
 You can also update your `pyproject.toml` (alredy done in [python-template](https://github.com/batistagroup/python-template/)) to have strict enabled by default.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,12 @@
 site_name: Batista Group Knowledgebase
+repo_url: https://github.com/batistagroup/knowledgebase
+repo_name: batistagroup/knowledgebase
+copyright: CC-BY 4.0 &copy; 2025 Batista Group
 theme:
   name: material
   features:
     - content.code.copy
+    - navigation.footer
     
 extra_css:
 - stylesheets/extra.css


### PR DESCRIPTION
a lot of links were broken because mkdocs expected a relative, not absolute path. fixed it and added link to repo in header